### PR TITLE
Call the callback the same way as superagent

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,12 +33,18 @@ var jsonp = function(options){
 	this.options = _.defaults(options, { callbackName : 'cb' });
 	this.callbackName = 'superagentCallback' + new Date().valueOf() + parseInt(Math.random() * 1000);
 
-
-	window[this.callbackName] = function(data){
-		this.callback.apply(this, [data]);
-	}.bind(this);
+	window[this.callbackName] = callbackWrapper.bind(this);
 
 	return this;
+};
+
+var callbackWrapper = function(data) {
+	var err = null;
+	var res = {
+		body: data
+	};
+
+	this.callback.apply(this, [err, res]);
 };
 
 var end = function(callback){


### PR DESCRIPTION
Pass two arguments to the callback
- First argument is an error status (unused here)
- Second argument is the response object (see [documentation](http://visionmedia.github.io/superagent/#response-properties))
