### PR TITLE
Specify callbackParam value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ var superagent = require('superagent');
 
 let jsonp = require('superagent-jsonp');
 
-superagent.get('http://example.com/foo.json').use(jsonp).end(function(err, res){
+superagent.get('http://example.com/foo.json').use(jsonp({
+ callbackParam:'jsoncallback'
+})).end(function(err, res){
   // everything is as normal
 });
 


### PR DESCRIPTION
This pull request is to configuring `callbackParam` value.

CURRENT:

```
superagent.get('http://example.com/foo.json').use(jsonp).end(function(err, res){
  // everything is as normal
});
```

THIS PULL REQUEST can do also below:

```
superagent.get('http://example.com/foo.json').use(jsonp({
  callbackParam:'jsoncallback'
})).end(function(err, res){
  // everything is as normal
});
```
